### PR TITLE
Add DV feature to FIT

### DIFF
--- a/zgoubidoo/commands/commands.py
+++ b/zgoubidoo/commands/commands.py
@@ -336,7 +336,7 @@ class Fit(Command):
         """)
         for p in self.PARAMS:
             command.append(f"""
-        {p['IR']} {p['IP']} {p['XC']} [-30.0,30.0]
+        {p['IR']} {p['IP']} {p['XC']} {p['DV']}
         """)
         command.append(f"""
         {len(self.CONSTRAINTS)} {self.PENALTY:.12e} {self.ITERATIONS}


### PR DESCRIPTION
The previous version had a variation range [-30,+30] for the [V_min,V_max] values of the FIT procedure. Now this variation range is now governed by 'DV' which allows to vary a given parameter by : parameter + (1+/- DV).